### PR TITLE
Change from .trunk/branch/leaf to indices for accessing filesystem layers

### DIFF
--- a/autofile/fs.py
+++ b/autofile/fs.py
@@ -1,4 +1,9 @@
-""" filesystem library
+"""
+autofile.fs
+***********
+
+Generate autofile.model.FileSystem objects for generating and interacting with
+a filesystem.
 """
 from autofile.system import file_
 from autofile.system import info
@@ -6,7 +11,7 @@ from autofile.system import dir_
 from autofile.system import model
 
 
-class FilePrefix():
+class _FilePrefix():
     """ file prefixes """
     RUN = 'run'
     BUILD = 'build'
@@ -23,7 +28,7 @@ class FilePrefix():
     LJ = 'lj'
 
 
-class FileAttributeName():
+class _FileAttributeName():
     """ DataFile attribute names """
     INFO = 'info'
     INPUT = 'input'
@@ -53,65 +58,50 @@ class FileAttributeName():
     LJ_SIG = 'lennard_jones_sigma'
 
 
-class SeriesAttributeName():
-    """ DataSeries attribute names
-    """
-    TRUNK = 'trunk'
-    BRANCH = 'branch'
-    BRANCH1 = 'branch1'
-    BRANCH2 = 'branch2'
-    LEAF = 'leaf'
-
-
 def species(prefix):
     """ construct the species filesystem [trunk/leaf]
 
-    layers:
-     - trunk (specifiers: [])
-     - leaf (specifiers: [ich, chg, mul])
+    two layers with the following specifiers:
+    1. []
+    2. [ich, chg, mul]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
     """
     trunk_ds = dir_.species_trunk(prefix)
     leaf_ds = dir_.species_leaf(prefix, root_ds=trunk_ds)
-
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def theory(prefix):
     """ construct the theory filesystem [leaf]
 
-    layers:
-     - leaf (specifiers: [method, basis, orb_restricted])
+    one layer with the following specifiers: [method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
     """
     leaf_ds = dir_.theory_leaf(prefix)
 
-    geom_dfile = file_.geometry(FilePrefix.GEOM)
-    ene_dfile = file_.energy(FilePrefix.GEOM)
-    zmat_dfile = file_.zmatrix(FilePrefix.GEOM)
-    hess_dfile = file_.hessian(FilePrefix.HESS)
+    geom_dfile = file_.geometry(_FilePrefix.GEOM)
+    ene_dfile = file_.energy(_FilePrefix.GEOM)
+    zmat_dfile = file_.zmatrix(_FilePrefix.GEOM)
+    hess_dfile = file_.hessian(_FilePrefix.HESS)
     leaf_ds.add_data_files({
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.GEOM: geom_dfile,
-        FileAttributeName.HESS: hess_dfile,
-        FileAttributeName.ZMAT: zmat_dfile})
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.GEOM: geom_dfile,
+        _FileAttributeName.HESS: hess_dfile,
+        _FileAttributeName.ZMAT: zmat_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (leaf_ds,)
 
 
 def conformer(prefix):
     """ construct the conformer filesystem [trunk/leaf]
 
-    layers:
-     - trunk (specifiers: [])
-     - leaf (specifiers: [cid])
+    two layers with the following specifiers:
+    1. []
+    2. [cid]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -119,70 +109,68 @@ def conformer(prefix):
     trunk_ds = dir_.conformer_trunk(prefix)
     leaf_ds = dir_.conformer_leaf(prefix, root_ds=trunk_ds)
 
-    min_ene_dfile = file_.energy(FilePrefix.MIN)
-    vma_dfile = file_.vmatrix(FilePrefix.CONF)
-    inf_dfile = file_.information(FilePrefix.CONF,
+    min_ene_dfile = file_.energy(_FilePrefix.MIN)
+    vma_dfile = file_.vmatrix(_FilePrefix.CONF)
+    inf_dfile = file_.information(_FilePrefix.CONF,
                                   function=info.conformer_trunk)
-    traj_dfile = file_.trajectory(FilePrefix.CONF)
+    traj_dfile = file_.trajectory(_FilePrefix.CONF)
     trunk_ds.add_data_files({
-        FileAttributeName.VMATRIX: vma_dfile,
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.ENERGY: min_ene_dfile,
-        FileAttributeName.TRAJ: traj_dfile})
+        _FileAttributeName.VMATRIX: vma_dfile,
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.ENERGY: min_ene_dfile,
+        _FileAttributeName.TRAJ: traj_dfile})
 
-    geom_inf_dfile = file_.information(FilePrefix.GEOM, function=info.run)
-    grad_inf_dfile = file_.information(FilePrefix.GRAD, function=info.run)
-    hess_inf_dfile = file_.information(FilePrefix.HESS, function=info.run)
-    geom_inp_dfile = file_.input_file(FilePrefix.GEOM)
-    grad_inp_dfile = file_.input_file(FilePrefix.GRAD)
-    hess_inp_dfile = file_.input_file(FilePrefix.HESS)
-    ene_dfile = file_.energy(FilePrefix.GEOM)
-    geom_dfile = file_.geometry(FilePrefix.GEOM)
-    zmat_dfile = file_.zmatrix(FilePrefix.GEOM)
-    grad_dfile = file_.gradient(FilePrefix.GRAD)
-    hess_dfile = file_.hessian(FilePrefix.HESS)
-    hfreq_dfile = file_.harmonic_frequencies(FilePrefix.HESS)
+    geom_inf_dfile = file_.information(_FilePrefix.GEOM, function=info.run)
+    grad_inf_dfile = file_.information(_FilePrefix.GRAD, function=info.run)
+    hess_inf_dfile = file_.information(_FilePrefix.HESS, function=info.run)
+    geom_inp_dfile = file_.input_file(_FilePrefix.GEOM)
+    grad_inp_dfile = file_.input_file(_FilePrefix.GRAD)
+    hess_inp_dfile = file_.input_file(_FilePrefix.HESS)
+    ene_dfile = file_.energy(_FilePrefix.GEOM)
+    geom_dfile = file_.geometry(_FilePrefix.GEOM)
+    zmat_dfile = file_.zmatrix(_FilePrefix.GEOM)
+    grad_dfile = file_.gradient(_FilePrefix.GRAD)
+    hess_dfile = file_.hessian(_FilePrefix.HESS)
+    hfreq_dfile = file_.harmonic_frequencies(_FilePrefix.HESS)
     vpt2_inf_dfile = file_.information(
-        FilePrefix.VPT2, function=info.vpt2_trunk)
-    vpt2_inp_dfile = file_.input_file(FilePrefix.VPT2)
-    anhfreq_dfile = file_.anharmonic_frequencies(FilePrefix.VPT2)
-    anhzpve_dfile = file_.anharmonic_zpve(FilePrefix.VPT2)
-    xmat_dfile = file_.anharmonicity_matrix(FilePrefix.VPT2)
-    vibrot_mat_dfile = file_.vibro_rot_alpha_matrix(FilePrefix.VPT2)
-    centrif_dist_dfile = file_.quartic_centrifugal_dist_consts(FilePrefix.VPT2)
+        _FilePrefix.VPT2, function=info.vpt2_trunk)
+    vpt2_inp_dfile = file_.input_file(_FilePrefix.VPT2)
+    anhfreq_dfile = file_.anharmonic_frequencies(_FilePrefix.VPT2)
+    anhzpve_dfile = file_.anharmonic_zpve(_FilePrefix.VPT2)
+    xmat_dfile = file_.anharmonicity_matrix(_FilePrefix.VPT2)
+    vibrot_mat_dfile = file_.vibro_rot_alpha_matrix(_FilePrefix.VPT2)
+    centrif_dist_dfile = file_.quartic_centrifugal_dist_consts(_FilePrefix.VPT2)
 
     leaf_ds.add_data_files({
-        FileAttributeName.GEOM_INFO: geom_inf_dfile,
-        FileAttributeName.GRAD_INFO: grad_inf_dfile,
-        FileAttributeName.HESS_INFO: hess_inf_dfile,
-        FileAttributeName.GEOM_INPUT: geom_inp_dfile,
-        FileAttributeName.GRAD_INPUT: grad_inp_dfile,
-        FileAttributeName.HESS_INPUT: hess_inp_dfile,
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.GEOM: geom_dfile,
-        FileAttributeName.ZMAT: zmat_dfile,
-        FileAttributeName.GRAD: grad_dfile,
-        FileAttributeName.HESS: hess_dfile,
-        FileAttributeName.HFREQ: hfreq_dfile,
-        FileAttributeName.VPT2_INFO: vpt2_inf_dfile,
-        FileAttributeName.VPT2_INPUT: vpt2_inp_dfile,
-        FileAttributeName.ANHFREQ: anhfreq_dfile,
-        FileAttributeName.ANHZPVE: anhzpve_dfile,
-        FileAttributeName.XMAT: xmat_dfile,
-        FileAttributeName.VIBROT_MAX: vibrot_mat_dfile,
-        FileAttributeName.CENTIF_DIST: centrif_dist_dfile})
+        _FileAttributeName.GEOM_INFO: geom_inf_dfile,
+        _FileAttributeName.GRAD_INFO: grad_inf_dfile,
+        _FileAttributeName.HESS_INFO: hess_inf_dfile,
+        _FileAttributeName.GEOM_INPUT: geom_inp_dfile,
+        _FileAttributeName.GRAD_INPUT: grad_inp_dfile,
+        _FileAttributeName.HESS_INPUT: hess_inp_dfile,
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.GEOM: geom_dfile,
+        _FileAttributeName.ZMAT: zmat_dfile,
+        _FileAttributeName.GRAD: grad_dfile,
+        _FileAttributeName.HESS: hess_dfile,
+        _FileAttributeName.HFREQ: hfreq_dfile,
+        _FileAttributeName.VPT2_INFO: vpt2_inf_dfile,
+        _FileAttributeName.VPT2_INPUT: vpt2_inp_dfile,
+        _FileAttributeName.ANHFREQ: anhfreq_dfile,
+        _FileAttributeName.ANHZPVE: anhzpve_dfile,
+        _FileAttributeName.XMAT: xmat_dfile,
+        _FileAttributeName.VIBROT_MAX: vibrot_mat_dfile,
+        _FileAttributeName.CENTIF_DIST: centrif_dist_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def single_point(prefix):
     """ construct the single-point filesystem [trunk/leaf]
 
-    layers:
-     - trunk (specifiers: [])
-     - leaf (specifiers: [method, basis, orb_restricted])
+    two layers with the following specifiers:
+    1. []
+    2. [method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -190,26 +178,23 @@ def single_point(prefix):
     trunk_ds = dir_.single_point_trunk(prefix)
     leaf_ds = dir_.single_point_leaf(prefix, root_ds=trunk_ds)
 
-    inp_dfile = file_.input_file(FilePrefix.SP)
-    inf_dfile = file_.information(FilePrefix.SP, function=info.run)
-    ene_dfile = file_.energy(FilePrefix.SP)
+    inp_dfile = file_.input_file(_FilePrefix.SP)
+    inf_dfile = file_.information(_FilePrefix.SP, function=info.run)
+    ene_dfile = file_.energy(_FilePrefix.SP)
     leaf_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.INPUT: inp_dfile,
-        FileAttributeName.ENERGY: ene_dfile})
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.INPUT: inp_dfile,
+        _FileAttributeName.ENERGY: ene_dfile})
 
-    dir_fs = model.FileSystem({
-        SeriesAttributeName.TRUNK: trunk_ds,
-        SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def high_spin(prefix):
     """ construct the high-spin, single-point filesystem [trunk/leaf]
 
-    layers:
-     - trunk (specifiers: [])
-     - leaf (specifiers: [method, basis, orb_restricted])
+    two layers with the following specifiers:
+    1. []
+    2. [method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -217,27 +202,24 @@ def high_spin(prefix):
     trunk_ds = dir_.high_spin_trunk(prefix)
     leaf_ds = dir_.high_spin_leaf(prefix, root_ds=trunk_ds)
 
-    inp_dfile = file_.input_file(FilePrefix.HS)
-    inf_dfile = file_.information(FilePrefix.HS, function=info.run)
-    ene_dfile = file_.energy(FilePrefix.HS)
+    inp_dfile = file_.input_file(_FilePrefix.HS)
+    inf_dfile = file_.information(_FilePrefix.HS, function=info.run)
+    ene_dfile = file_.energy(_FilePrefix.HS)
     leaf_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.INPUT: inp_dfile,
-        FileAttributeName.ENERGY: ene_dfile})
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.INPUT: inp_dfile,
+        _FileAttributeName.ENERGY: ene_dfile})
 
-    dir_fs = model.FileSystem({
-        SeriesAttributeName.TRUNK: trunk_ds,
-        SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def scan(prefix):
     """ construct the scan filesystem
 
-    layers:
-     - trunk (specifiers: [])
-     - branch (specifiers: [coo_names])
-     - leaf (specifiers: [coo_names, coo_vals])
+    three layers with the following specifiers:
+    1. []
+    2. [coo_names]
+    3. [coo_names, coo_vals]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -246,57 +228,53 @@ def scan(prefix):
     branch_ds = dir_.scan_branch(prefix, root_ds=trunk_ds)
     leaf_ds = dir_.scan_leaf(prefix, root_ds=branch_ds)
 
-    vma_dfile = file_.vmatrix(FilePrefix.SCAN)
+    vma_dfile = file_.vmatrix(_FilePrefix.SCAN)
     trunk_ds.add_data_files({
-        FileAttributeName.VMATRIX: vma_dfile})
+        _FileAttributeName.VMATRIX: vma_dfile})
 
-    inf_dfile = file_.information(FilePrefix.SCAN, function=info.scan_branch)
-    traj_dfile = file_.trajectory(FilePrefix.SCAN)
+    inf_dfile = file_.information(_FilePrefix.SCAN, function=info.scan_branch)
+    traj_dfile = file_.trajectory(_FilePrefix.SCAN)
     branch_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.TRAJ: traj_dfile})
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.TRAJ: traj_dfile})
 
-    geom_inf_dfile = file_.information(FilePrefix.GEOM, function=info.run)
-    grad_inf_dfile = file_.information(FilePrefix.GRAD, function=info.run)
-    hess_inf_dfile = file_.information(FilePrefix.HESS, function=info.run)
-    geom_inp_dfile = file_.input_file(FilePrefix.GEOM)
-    grad_inp_dfile = file_.input_file(FilePrefix.GRAD)
-    hess_inp_dfile = file_.input_file(FilePrefix.HESS)
-    ene_dfile = file_.energy(FilePrefix.GEOM)
-    geom_dfile = file_.geometry(FilePrefix.GEOM)
-    zmat_dfile = file_.zmatrix(FilePrefix.GEOM)
-    grad_dfile = file_.gradient(FilePrefix.GRAD)
-    hess_dfile = file_.hessian(FilePrefix.HESS)
-    hfreq_dfile = file_.harmonic_frequencies(FilePrefix.HESS)
+    geom_inf_dfile = file_.information(_FilePrefix.GEOM, function=info.run)
+    grad_inf_dfile = file_.information(_FilePrefix.GRAD, function=info.run)
+    hess_inf_dfile = file_.information(_FilePrefix.HESS, function=info.run)
+    geom_inp_dfile = file_.input_file(_FilePrefix.GEOM)
+    grad_inp_dfile = file_.input_file(_FilePrefix.GRAD)
+    hess_inp_dfile = file_.input_file(_FilePrefix.HESS)
+    ene_dfile = file_.energy(_FilePrefix.GEOM)
+    geom_dfile = file_.geometry(_FilePrefix.GEOM)
+    zmat_dfile = file_.zmatrix(_FilePrefix.GEOM)
+    grad_dfile = file_.gradient(_FilePrefix.GRAD)
+    hess_dfile = file_.hessian(_FilePrefix.HESS)
+    hfreq_dfile = file_.harmonic_frequencies(_FilePrefix.HESS)
     leaf_ds.add_data_files({
-        FileAttributeName.GEOM_INFO: geom_inf_dfile,
-        FileAttributeName.GRAD_INFO: grad_inf_dfile,
-        FileAttributeName.HESS_INFO: hess_inf_dfile,
-        FileAttributeName.GEOM_INPUT: geom_inp_dfile,
-        FileAttributeName.GRAD_INPUT: grad_inp_dfile,
-        FileAttributeName.HESS_INPUT: hess_inp_dfile,
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.GEOM: geom_dfile,
-        FileAttributeName.ZMAT: zmat_dfile,
-        FileAttributeName.GRAD: grad_dfile,
-        FileAttributeName.HESS: hess_dfile,
-        FileAttributeName.HFREQ: hfreq_dfile})
+        _FileAttributeName.GEOM_INFO: geom_inf_dfile,
+        _FileAttributeName.GRAD_INFO: grad_inf_dfile,
+        _FileAttributeName.HESS_INFO: hess_inf_dfile,
+        _FileAttributeName.GEOM_INPUT: geom_inp_dfile,
+        _FileAttributeName.GRAD_INPUT: grad_inp_dfile,
+        _FileAttributeName.HESS_INPUT: hess_inp_dfile,
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.GEOM: geom_dfile,
+        _FileAttributeName.ZMAT: zmat_dfile,
+        _FileAttributeName.GRAD: grad_dfile,
+        _FileAttributeName.HESS: hess_dfile,
+        _FileAttributeName.HFREQ: hfreq_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.BRANCH: branch_ds,
-                               SeriesAttributeName.BRANCH1: branch_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, branch_ds, leaf_ds)
 
 
 def cscan(prefix):
     """ construct the constrained scan filesystem
 
-    layers:
-     - trunk (specifiers: [])
-     - branch1 (specifiers: [coo_names])
-     - branch2 (specifiers: [coo_names, coo_vals])
-     - leaf (specifiers: [coo_names, coo_vals, cons_coo_val_dct])
+    four layers with the following specifiers:
+    1. []
+    2. [coo_names]
+    3. [coo_names, coo_vals]
+    4. [coo_names, coo_vals, cons_coo_val_dct]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -306,55 +284,51 @@ def cscan(prefix):
     branch2_ds = dir_.cscan_branch2(prefix, root_ds=branch1_ds)
     leaf_ds = dir_.cscan_leaf(prefix, root_ds=branch2_ds)
 
-    vma_dfile = file_.vmatrix(FilePrefix.SCAN)
+    vma_dfile = file_.vmatrix(_FilePrefix.SCAN)
     trunk_ds.add_data_files({
-        FileAttributeName.VMATRIX: vma_dfile})
+        _FileAttributeName.VMATRIX: vma_dfile})
 
-    inf_dfile = file_.information(FilePrefix.SCAN, function=info.scan_branch)
-    traj_dfile = file_.trajectory(FilePrefix.SCAN)
+    inf_dfile = file_.information(_FilePrefix.SCAN, function=info.scan_branch)
+    traj_dfile = file_.trajectory(_FilePrefix.SCAN)
     branch1_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.TRAJ: traj_dfile})
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.TRAJ: traj_dfile})
 
-    geom_inf_dfile = file_.information(FilePrefix.GEOM, function=info.run)
-    grad_inf_dfile = file_.information(FilePrefix.GRAD, function=info.run)
-    hess_inf_dfile = file_.information(FilePrefix.HESS, function=info.run)
-    geom_inp_dfile = file_.input_file(FilePrefix.GEOM)
-    grad_inp_dfile = file_.input_file(FilePrefix.GRAD)
-    hess_inp_dfile = file_.input_file(FilePrefix.HESS)
-    ene_dfile = file_.energy(FilePrefix.GEOM)
-    geom_dfile = file_.geometry(FilePrefix.GEOM)
-    zmat_dfile = file_.zmatrix(FilePrefix.GEOM)
-    grad_dfile = file_.gradient(FilePrefix.GRAD)
-    hess_dfile = file_.hessian(FilePrefix.HESS)
-    hfreq_dfile = file_.harmonic_frequencies(FilePrefix.HESS)
+    geom_inf_dfile = file_.information(_FilePrefix.GEOM, function=info.run)
+    grad_inf_dfile = file_.information(_FilePrefix.GRAD, function=info.run)
+    hess_inf_dfile = file_.information(_FilePrefix.HESS, function=info.run)
+    geom_inp_dfile = file_.input_file(_FilePrefix.GEOM)
+    grad_inp_dfile = file_.input_file(_FilePrefix.GRAD)
+    hess_inp_dfile = file_.input_file(_FilePrefix.HESS)
+    ene_dfile = file_.energy(_FilePrefix.GEOM)
+    geom_dfile = file_.geometry(_FilePrefix.GEOM)
+    zmat_dfile = file_.zmatrix(_FilePrefix.GEOM)
+    grad_dfile = file_.gradient(_FilePrefix.GRAD)
+    hess_dfile = file_.hessian(_FilePrefix.HESS)
+    hfreq_dfile = file_.harmonic_frequencies(_FilePrefix.HESS)
     leaf_ds.add_data_files({
-        FileAttributeName.GEOM_INFO: geom_inf_dfile,
-        FileAttributeName.GRAD_INFO: grad_inf_dfile,
-        FileAttributeName.HESS_INFO: hess_inf_dfile,
-        FileAttributeName.GEOM_INPUT: geom_inp_dfile,
-        FileAttributeName.GRAD_INPUT: grad_inp_dfile,
-        FileAttributeName.HESS_INPUT: hess_inp_dfile,
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.GEOM: geom_dfile,
-        FileAttributeName.ZMAT: zmat_dfile,
-        FileAttributeName.GRAD: grad_dfile,
-        FileAttributeName.HESS: hess_dfile,
-        FileAttributeName.HFREQ: hfreq_dfile})
+        _FileAttributeName.GEOM_INFO: geom_inf_dfile,
+        _FileAttributeName.GRAD_INFO: grad_inf_dfile,
+        _FileAttributeName.HESS_INFO: hess_inf_dfile,
+        _FileAttributeName.GEOM_INPUT: geom_inp_dfile,
+        _FileAttributeName.GRAD_INPUT: grad_inp_dfile,
+        _FileAttributeName.HESS_INPUT: hess_inp_dfile,
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.GEOM: geom_dfile,
+        _FileAttributeName.ZMAT: zmat_dfile,
+        _FileAttributeName.GRAD: grad_dfile,
+        _FileAttributeName.HESS: hess_dfile,
+        _FileAttributeName.HFREQ: hfreq_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.BRANCH1: branch1_ds,
-                               SeriesAttributeName.BRANCH2: branch2_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, branch1_ds, branch2_ds, leaf_ds)
 
 
 def tau(prefix):
     """ construct the tau filesystem
 
-    layers:
-     - trunk (specifiers: [])
-     - leaf (specifiers: [tid])
+    two layers with the following specifiers:
+    1. []
+    4. [tid]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -362,53 +336,51 @@ def tau(prefix):
     trunk_ds = dir_.tau_trunk(prefix)
     leaf_ds = dir_.tau_leaf(prefix, root_ds=trunk_ds)
 
-    vma_dfile = file_.vmatrix(FilePrefix.TAU)
-    inf_dfile = file_.information(FilePrefix.TAU,
+    vma_dfile = file_.vmatrix(_FilePrefix.TAU)
+    inf_dfile = file_.information(_FilePrefix.TAU,
                                   function=info.tau_trunk)
-    traj_dfile = file_.trajectory(FilePrefix.TAU)
+    traj_dfile = file_.trajectory(_FilePrefix.TAU)
     trunk_ds.add_data_files({
-        FileAttributeName.VMATRIX: vma_dfile,
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.TRAJ: traj_dfile})
+        _FileAttributeName.VMATRIX: vma_dfile,
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.TRAJ: traj_dfile})
 
-    geom_inf_dfile = file_.information(FilePrefix.GEOM, function=info.run)
-    grad_inf_dfile = file_.information(FilePrefix.GRAD, function=info.run)
-    hess_inf_dfile = file_.information(FilePrefix.HESS, function=info.run)
-    geom_inp_dfile = file_.input_file(FilePrefix.GEOM)
-    grad_inp_dfile = file_.input_file(FilePrefix.GRAD)
-    hess_inp_dfile = file_.input_file(FilePrefix.HESS)
-    ene_dfile = file_.energy(FilePrefix.GEOM)
-    geom_dfile = file_.geometry(FilePrefix.GEOM)
-    zmat_dfile = file_.zmatrix(FilePrefix.GEOM)
-    grad_dfile = file_.gradient(FilePrefix.GRAD)
-    hess_dfile = file_.hessian(FilePrefix.HESS)
-    hfreq_dfile = file_.harmonic_frequencies(FilePrefix.HESS)
+    geom_inf_dfile = file_.information(_FilePrefix.GEOM, function=info.run)
+    grad_inf_dfile = file_.information(_FilePrefix.GRAD, function=info.run)
+    hess_inf_dfile = file_.information(_FilePrefix.HESS, function=info.run)
+    geom_inp_dfile = file_.input_file(_FilePrefix.GEOM)
+    grad_inp_dfile = file_.input_file(_FilePrefix.GRAD)
+    hess_inp_dfile = file_.input_file(_FilePrefix.HESS)
+    ene_dfile = file_.energy(_FilePrefix.GEOM)
+    geom_dfile = file_.geometry(_FilePrefix.GEOM)
+    zmat_dfile = file_.zmatrix(_FilePrefix.GEOM)
+    grad_dfile = file_.gradient(_FilePrefix.GRAD)
+    hess_dfile = file_.hessian(_FilePrefix.HESS)
+    hfreq_dfile = file_.harmonic_frequencies(_FilePrefix.HESS)
     leaf_ds.add_data_files({
-        FileAttributeName.GEOM_INFO: geom_inf_dfile,
-        FileAttributeName.GRAD_INFO: grad_inf_dfile,
-        FileAttributeName.HESS_INFO: hess_inf_dfile,
-        FileAttributeName.GEOM_INPUT: geom_inp_dfile,
-        FileAttributeName.GRAD_INPUT: grad_inp_dfile,
-        FileAttributeName.HESS_INPUT: hess_inp_dfile,
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.GEOM: geom_dfile,
-        FileAttributeName.ZMAT: zmat_dfile,
-        FileAttributeName.GRAD: grad_dfile,
-        FileAttributeName.HESS: hess_dfile,
-        FileAttributeName.HFREQ: hfreq_dfile})
+        _FileAttributeName.GEOM_INFO: geom_inf_dfile,
+        _FileAttributeName.GRAD_INFO: grad_inf_dfile,
+        _FileAttributeName.HESS_INFO: hess_inf_dfile,
+        _FileAttributeName.GEOM_INPUT: geom_inp_dfile,
+        _FileAttributeName.GRAD_INPUT: grad_inp_dfile,
+        _FileAttributeName.HESS_INPUT: hess_inp_dfile,
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.GEOM: geom_dfile,
+        _FileAttributeName.ZMAT: zmat_dfile,
+        _FileAttributeName.GRAD: grad_dfile,
+        _FileAttributeName.HESS: hess_dfile,
+        _FileAttributeName.HFREQ: hfreq_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def energy_transfer(prefix):
     """ construct the energy transfer filesystem [trunk/leaf]
 
-    layers:
-     - trunk (specifiers: [])
-     - branch (specifiers: [ich, chg, mul])
-     - leaf (specifiers: [method, basis, orb_restricted])
+    three layers with the following specifiers:
+    1. []
+    2. [ich, chg, mul]
+    3. [ich, chg, mul, method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -417,39 +389,32 @@ def energy_transfer(prefix):
     branch_ds = dir_.energy_transfer_branch(prefix, root_ds=trunk_ds)
     leaf_ds = dir_.energy_transfer_leaf(prefix, root_ds=branch_ds)
 
-    # inp_dfile = file_.input_file(FilePrefix.LJ)
+    # inp_dfile = file_.input_file(_FilePrefix.LJ)
     inf_dfile = file_.information(
-        FilePrefix.LJ, function=info.lennard_jones)
-    ene_dfile = file_.energy(FilePrefix.LJ)
-    eps_dfile = file_.lennard_jones_epsilon(FilePrefix.LJ)
-    sig_dfile = file_.lennard_jones_sigma(FilePrefix.LJ)
-    traj_dfile = file_.trajectory(FilePrefix.LJ)
+        _FilePrefix.LJ, function=info.lennard_jones)
+    ene_dfile = file_.energy(_FilePrefix.LJ)
+    eps_dfile = file_.lennard_jones_epsilon(_FilePrefix.LJ)
+    sig_dfile = file_.lennard_jones_sigma(_FilePrefix.LJ)
+    traj_dfile = file_.trajectory(_FilePrefix.LJ)
 
     trunk_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile})
+        _FileAttributeName.INFO: inf_dfile})
 
     leaf_ds.add_data_files({
-        #    FileAttributeName.INFO: inf_dfile,
-        #    FileAttributeName.INPUT: inp_dfile,
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.LJ_EPS: eps_dfile,
-        FileAttributeName.LJ_SIG: sig_dfile,
-        FileAttributeName.TRAJ: traj_dfile})
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.LJ_EPS: eps_dfile,
+        _FileAttributeName.LJ_SIG: sig_dfile,
+        _FileAttributeName.TRAJ: traj_dfile})
 
-    dir_fs = model.FileSystem({
-        SeriesAttributeName.TRUNK: trunk_ds,
-        SeriesAttributeName.BRANCH: branch_ds,
-        SeriesAttributeName.BRANCH1: branch_ds,
-        SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, branch_ds, leaf_ds)
 
 
 def reaction(prefix):
     """ construct the reaction filesystem
 
-    layers:
-     - trunk (specifiers: [])
-     - leaf (specifiers: [rxn_ichs, rxn_chgs, rxn_muls, ts_mul])
+    two layers with the following specifiers:
+    1. []
+    2. [rxn_ichs, rxn_chgs, rxn_muls, ts_mul]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -457,68 +422,62 @@ def reaction(prefix):
     trunk_ds = dir_.reaction_trunk(prefix)
     leaf_ds = dir_.reaction_leaf(prefix, root_ds=trunk_ds)
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def ts(prefix):
     """ construct the ts filesystem
 
-    layers:
-     - trunk (specifiers: [])
+    one layer without specifiers
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
     """
     trunk_ds = dir_.ts_trunk(prefix)
 
-    geom_dfile = file_.geometry(FilePrefix.GEOM)
-    ene_dfile = file_.energy(FilePrefix.GEOM)
-    zmat_dfile = file_.zmatrix(FilePrefix.GEOM)
+    geom_dfile = file_.geometry(_FilePrefix.GEOM)
+    ene_dfile = file_.energy(_FilePrefix.GEOM)
+    zmat_dfile = file_.zmatrix(_FilePrefix.GEOM)
     trunk_ds.add_data_files({
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.GEOM: geom_dfile,
-        FileAttributeName.ZMAT: zmat_dfile})
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.GEOM: geom_dfile,
+        _FileAttributeName.ZMAT: zmat_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds})
-    return dir_fs
+    return (trunk_ds,)
 
 
 def direction(prefix):
     """ filesystem object for reaction direction
 
-    layers:
-     - leaf (specifiers: [forw])
+    one layer with the following specifiers: [forw]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
     """
     leaf_ds = dir_.direction_leaf(prefix)
 
-    inf_dfile = file_.information(FilePrefix.GEOM, function=info.run)
-    inp_dfile = file_.input_file(FilePrefix.GEOM)
-    ene_dfile = file_.energy(FilePrefix.GEOM)
-    geom_dfile = file_.geometry(FilePrefix.GEOM)
-    zmat_dfile = file_.zmatrix(FilePrefix.GEOM)
+    inf_dfile = file_.information(_FilePrefix.GEOM, function=info.run)
+    inp_dfile = file_.input_file(_FilePrefix.GEOM)
+    ene_dfile = file_.energy(_FilePrefix.GEOM)
+    geom_dfile = file_.geometry(_FilePrefix.GEOM)
+    zmat_dfile = file_.zmatrix(_FilePrefix.GEOM)
 
     leaf_ds.add_data_files({
-        FileAttributeName.GEOM_INPUT: inp_dfile,
-        FileAttributeName.GEOM_INFO: inf_dfile,
-        FileAttributeName.ENERGY: ene_dfile,
-        FileAttributeName.GEOM: geom_dfile,
-        FileAttributeName.ZMAT: zmat_dfile})
+        _FileAttributeName.GEOM_INPUT: inp_dfile,
+        _FileAttributeName.GEOM_INFO: inf_dfile,
+        _FileAttributeName.ENERGY: ene_dfile,
+        _FileAttributeName.GEOM: geom_dfile,
+        _FileAttributeName.ZMAT: zmat_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (leaf_ds,)
 
 
 def run(prefix):
-    """ construct the run filesystem [trunk/leaf]
+    """ construct the run filesystem
 
-    layers:
-     - trunk (specifiers: [])
-     - leaf (specifiers: [job])
+    two layers with the following specifiers:
+    1. []
+    2. [job]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -526,50 +485,46 @@ def run(prefix):
     trunk_ds = dir_.run_trunk(prefix)
     leaf_ds = dir_.run_leaf(prefix, root_ds=trunk_ds)
 
-    inf_dfile = file_.information(FilePrefix.RUN, function=info.run)
-    inp_dfile = file_.input_file(FilePrefix.RUN)
-    out_dfile = file_.output_file(FilePrefix.RUN)
+    inf_dfile = file_.information(_FilePrefix.RUN, function=info.run)
+    inp_dfile = file_.input_file(_FilePrefix.RUN)
+    out_dfile = file_.output_file(_FilePrefix.RUN)
     trunk_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile})
+        _FileAttributeName.INFO: inf_dfile})
     leaf_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.INPUT: inp_dfile,
-        FileAttributeName.OUTPUT: out_dfile})
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.INPUT: inp_dfile,
+        _FileAttributeName.OUTPUT: out_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def subrun(prefix):
-    """ construct the subrun filesystem [leaf]
+    """ construct the subrun filesystem
 
-    layers:
-     - leaf (specifiers: [macro_idx, micro_idx])
+    one layer with the following specifiers: [macro_idx, micro_idx]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
     """
     leaf_ds = dir_.subrun_leaf(prefix)
 
-    inf_dfile = file_.information(FilePrefix.RUN, function=info.run)
-    inp_dfile = file_.input_file(FilePrefix.RUN)
-    out_dfile = file_.output_file(FilePrefix.RUN)
+    inf_dfile = file_.information(_FilePrefix.RUN, function=info.run)
+    inp_dfile = file_.input_file(_FilePrefix.RUN)
+    out_dfile = file_.output_file(_FilePrefix.RUN)
     leaf_ds.add_data_files({
-        FileAttributeName.INFO: inf_dfile,
-        FileAttributeName.INPUT: inp_dfile,
-        FileAttributeName.OUTPUT: out_dfile})
+        _FileAttributeName.INFO: inf_dfile,
+        _FileAttributeName.INPUT: inp_dfile,
+        _FileAttributeName.OUTPUT: out_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (leaf_ds,)
 
 
 def build(prefix):
     """ construct the build filesystem
 
-    layers:
-     - trunk (specifiers: [head])
-     - leaf (specifiers: [head, num])
+    two layers with the following specifiers:
+    1. [head]
+    2. [head, num]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -577,15 +532,13 @@ def build(prefix):
     trunk_ds = dir_.build_trunk(prefix)
     leaf_ds = dir_.build_leaf(prefix, root_ds=trunk_ds)
 
-    inp_dfile = file_.input_file(FilePrefix.BUILD)
-    out_dfile = file_.output_file(FilePrefix.BUILD)
+    inp_dfile = file_.input_file(_FilePrefix.BUILD)
+    out_dfile = file_.output_file(_FilePrefix.BUILD)
     leaf_ds.add_data_files({
-        FileAttributeName.INPUT: inp_dfile,
-        FileAttributeName.OUTPUT: out_dfile})
+        _FileAttributeName.INPUT: inp_dfile,
+        _FileAttributeName.OUTPUT: out_dfile})
 
-    dir_fs = model.FileSystem({SeriesAttributeName.TRUNK: trunk_ds,
-                               SeriesAttributeName.LEAF: leaf_ds})
-    return dir_fs
+    return (trunk_ds, leaf_ds)
 
 
 def _process_root_args(root_fs=None, top_ds_name=None):

--- a/autofile/fs.py
+++ b/autofile/fs.py
@@ -59,11 +59,11 @@ class _FileAttributeName():
 
 
 def species(prefix):
-    """ construct the species filesystem [trunk/leaf]
+    """ construct the species filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. []
-    2. [ich, chg, mul]
+    specifiers:
+        0 - []
+        1 - [ich, chg, mul]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -74,9 +74,10 @@ def species(prefix):
 
 
 def theory(prefix):
-    """ construct the theory filesystem [leaf]
+    """ construct the theory filesystem (1 layer)
 
-    one layer with the following specifiers: [method, basis, orb_type]
+    specifiers:
+        0 - [method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -97,11 +98,11 @@ def theory(prefix):
 
 
 def conformer(prefix):
-    """ construct the conformer filesystem [trunk/leaf]
+    """ construct the conformer filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. []
-    2. [cid]
+    specifiers:
+        0 - []
+        1 - [cid]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -166,11 +167,11 @@ def conformer(prefix):
 
 
 def single_point(prefix):
-    """ construct the single-point filesystem [trunk/leaf]
+    """ construct the single-point filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. []
-    2. [method, basis, orb_type]
+    specifiers:
+        0 - []
+        1 - [method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -190,11 +191,11 @@ def single_point(prefix):
 
 
 def high_spin(prefix):
-    """ construct the high-spin, single-point filesystem [trunk/leaf]
+    """ construct the high-spin, single-point filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. []
-    2. [method, basis, orb_type]
+    specifiers:
+        0 - []
+        1 - [method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -214,12 +215,12 @@ def high_spin(prefix):
 
 
 def scan(prefix):
-    """ construct the scan filesystem
+    """ construct the scan filesystem (3 layers)
 
     three layers with the following specifiers:
-    1. []
-    2. [coo_names]
-    3. [coo_names, coo_vals]
+        0 - []
+        1 - [coo_names]
+        2 - [coo_names, coo_vals]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -268,13 +269,13 @@ def scan(prefix):
 
 
 def cscan(prefix):
-    """ construct the constrained scan filesystem
+    """ construct the constrained scan filesystem (4 layers)
 
-    four layers with the following specifiers:
-    1. []
-    2. [coo_names]
-    3. [coo_names, coo_vals]
-    4. [coo_names, coo_vals, cons_coo_val_dct]
+    specifiers:
+        0 - []
+        1 - [coo_names]
+        2 - [coo_names, coo_vals]
+        3 - [coo_names, coo_vals, cons_coo_val_dct]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -324,11 +325,11 @@ def cscan(prefix):
 
 
 def tau(prefix):
-    """ construct the tau filesystem
+    """ construct the tau filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. []
-    4. [tid]
+    specifiers:
+        0 - []
+        0 - [tid]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -375,12 +376,12 @@ def tau(prefix):
 
 
 def energy_transfer(prefix):
-    """ construct the energy transfer filesystem [trunk/leaf]
+    """ construct the energy transfer filesystem (3 layers)
 
-    three layers with the following specifiers:
-    1. []
-    2. [ich, chg, mul]
-    3. [ich, chg, mul, method, basis, orb_type]
+    specifiers:
+        0 - []
+        0 - [ich, chg, mul]
+        0 - [ich, chg, mul, method, basis, orb_type]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -410,11 +411,11 @@ def energy_transfer(prefix):
 
 
 def reaction(prefix):
-    """ construct the reaction filesystem
+    """ construct the reaction filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. []
-    2. [rxn_ichs, rxn_chgs, rxn_muls, ts_mul]
+    specifiers:
+        0 - []
+        1 - [rxn_ichs, rxn_chgs, rxn_muls, ts_mul]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -426,9 +427,10 @@ def reaction(prefix):
 
 
 def ts(prefix):
-    """ construct the ts filesystem
+    """ construct the ts filesystem (1 layer)
 
-    one layer without specifiers
+    specifiers:
+        0 - []  (none)
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -447,9 +449,10 @@ def ts(prefix):
 
 
 def direction(prefix):
-    """ filesystem object for reaction direction
+    """ filesystem object for reaction direction (1 layer)
 
-    one layer with the following specifiers: [forw]
+    specifiers:
+        0 - [forw]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -473,11 +476,11 @@ def direction(prefix):
 
 
 def run(prefix):
-    """ construct the run filesystem
+    """ construct the run filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. []
-    2. [job]
+    specifiers:
+        0 - []
+        1 - [job]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -499,9 +502,10 @@ def run(prefix):
 
 
 def subrun(prefix):
-    """ construct the subrun filesystem
+    """ construct the subrun filesystem (1 layer)
 
-    one layer with the following specifiers: [macro_idx, micro_idx]
+    specifiers:
+        0 - [macro_idx, micro_idx]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str
@@ -520,11 +524,11 @@ def subrun(prefix):
 
 
 def build(prefix):
-    """ construct the build filesystem
+    """ construct the build filesystem (2 layers)
 
-    two layers with the following specifiers:
-    1. [head]
-    2. [head, num]
+    specifiers:
+        0 - [head]
+        1 - [head, num]
 
     :param prefix: sets the path where this filesystem will sit
     :type prefix: str

--- a/autofile/test_.py
+++ b/autofile/test_.py
@@ -15,13 +15,13 @@ def test__direction():
     os.mkdir(prefix)
 
     dir_fs = autofile.fs.direction(prefix)
-    print(dir_fs.leaf.path([True]))
+    print(dir_fs[0].path([True]))
 
     ref_inp_str = '<input string>'
-    print(dir_fs.leaf.file.geometry_input.path([True]))
-    dir_fs.leaf.create([True])
-    dir_fs.leaf.file.geometry_input.write(ref_inp_str, [True])
-    assert dir_fs.leaf.file.geometry_input.read([True]) == ref_inp_str
+    print(dir_fs[0].file.geometry_input.path([True]))
+    dir_fs[0].create([True])
+    dir_fs[0].file.geometry_input.write(ref_inp_str, [True])
+    assert dir_fs[0].file.geometry_input.read([True]) == ref_inp_str
 
 
 def test__species():
@@ -32,11 +32,11 @@ def test__species():
 
     locs = ['InChI=1S/C2H2F2/c3-1-2-4/h1-2H/b2-1+', 0, 1]
     spc_fs = autofile.fs.species(prefix)
-    print(spc_fs.leaf.path(locs))
+    print(spc_fs[-1].path(locs))
 
-    assert not spc_fs.leaf.exists(locs)
-    spc_fs.leaf.create(locs)
-    assert spc_fs.leaf.exists(locs)
+    assert not spc_fs[-1].exists(locs)
+    spc_fs[-1].create(locs)
+    assert spc_fs[-1].exists(locs)
 
 
 def test__reaction():
@@ -53,11 +53,11 @@ def test__reaction():
         2
     ]
     rxn_fs = autofile.fs.reaction(prefix)
-    print(rxn_fs.leaf.path(locs))
+    print(rxn_fs[-1].path(locs))
 
-    assert not rxn_fs.leaf.exists(locs)
-    rxn_fs.leaf.create(locs)
-    assert rxn_fs.leaf.exists(locs)
+    assert not rxn_fs[-1].exists(locs)
+    rxn_fs[-1].create(locs)
+    assert rxn_fs[-1].exists(locs)
 
 
 def test__ts():
@@ -67,11 +67,11 @@ def test__ts():
     os.mkdir(prefix)
 
     ts_fs = autofile.fs.ts(prefix)
-    print(ts_fs.trunk.path())
+    print(ts_fs[0].path())
 
-    assert not ts_fs.trunk.exists()
-    ts_fs.trunk.create()
-    assert ts_fs.trunk.exists()
+    assert not ts_fs[0].exists()
+    ts_fs[0].create()
+    assert ts_fs[0].exists()
 
 
 def test__theory():
@@ -82,13 +82,13 @@ def test__theory():
 
     thy_fs = autofile.fs.theory(prefix)
     locs = ['hf', 'sto-3g', 'U']
-    print(thy_fs.leaf.path(locs))
+    print(thy_fs[-1].path(locs))
 
     ref_ene = 5.7
-    print(thy_fs.leaf.file.energy.path(locs))
-    thy_fs.leaf.create(locs)
-    thy_fs.leaf.file.energy.write(ref_ene, locs)
-    assert thy_fs.leaf.file.energy.read(locs) == ref_ene
+    print(thy_fs[-1].file.energy.path(locs))
+    thy_fs[-1].create(locs)
+    thy_fs[-1].file.energy.write(ref_ene, locs)
+    assert thy_fs[-1].file.energy.read(locs) == ref_ene
 
 
 def test__conformer():
@@ -99,11 +99,11 @@ def test__conformer():
 
     locs = [autofile.system.generate_new_conformer_id()]
     cnf_fs = autofile.fs.conformer(prefix)
-    print(cnf_fs.leaf.path(locs))
+    print(cnf_fs[-1].path(locs))
 
-    assert not cnf_fs.leaf.exists(locs)
-    cnf_fs.leaf.create(locs)
-    assert cnf_fs.leaf.exists(locs)
+    assert not cnf_fs[-1].exists(locs)
+    cnf_fs[-1].create(locs)
+    assert cnf_fs[-1].exists(locs)
 
 
 def test__tau():
@@ -114,11 +114,11 @@ def test__tau():
 
     locs = [autofile.system.generate_new_tau_id()]
     tau_fs = autofile.fs.tau(prefix)
-    print(tau_fs.leaf.path(locs))
+    print(tau_fs[-1].path(locs))
 
-    assert not tau_fs.leaf.exists(locs)
-    tau_fs.leaf.create(locs)
-    assert tau_fs.leaf.exists(locs)
+    assert not tau_fs[-1].exists(locs)
+    tau_fs[-1].create(locs)
+    assert tau_fs[-1].exists(locs)
 
 
 def test__single_point():
@@ -129,13 +129,13 @@ def test__single_point():
 
     sp_fs = autofile.fs.single_point(prefix)
     locs = ['hf', 'sto-3g', 'U']
-    print(sp_fs.leaf.path(locs))
+    print(sp_fs[-1].path(locs))
 
     ref_ene = 5.7
-    print(sp_fs.leaf.file.energy.path(locs))
-    sp_fs.leaf.create(locs)
-    sp_fs.leaf.file.energy.write(ref_ene, locs)
-    assert sp_fs.leaf.file.energy.read(locs) == ref_ene
+    print(sp_fs[-1].file.energy.path(locs))
+    sp_fs[-1].create(locs)
+    sp_fs[-1].file.energy.write(ref_ene, locs)
+    assert sp_fs[-1].file.energy.read(locs) == ref_ene
 
 
 # def test__energy_transfer():
@@ -146,35 +146,35 @@ def test__single_point():
 #
 #  #   spc_fs = autofile.fs.species(prefix)
 #  #   spc_locs = ['InChI=1S/C2H2F2/c3-1-2-4/h1-2H/b2-1+', 0, 1]
-#  #   spc_fs.leaf.create(spc_locs)
-#  #   spc_path = spc_fs.leaf.path(spc_locs)
-#  #   print(spc_fs.leaf.path(spc_locs))
+#  #   spc_fs[-1].create(spc_locs)
+#  #   spc_path = spc_fs[-1].path(spc_locs)
+#  #   print(spc_fs[-1].path(spc_locs))
 #
 #     etrans_fs = autofile.fs.energy_transfer(prefix)
 #     spc_locs = [['InChI=1S/C2H2F2/c3-1-2-4/h1-2H/b2-1+', 0, 1],[],[]]
-#     etrans_fs.leaf.create(spc_locs)
-#     etrans_spc_path = etrans_fs.leaf.path(spc_locs)
+#     etrans_fs[-1].create(spc_locs)
+#     etrans_spc_path = etrans_fs[-1].path(spc_locs)
 #     print(etrans_spc_path)
 #     thy_locs = [ 'hf', 'sto-3g', True]
 #     etrans_thy_fs = autofile.fs.theory(etrans_spc_path)
-#     etrans_thy_fs.leaf.create(thy_locs)
-#     etrans_thy_path = etrans_thy_fs.leaf.path(thy_locs)
+#     etrans_thy_fs[-1].create(thy_locs)
+#     etrans_thy_path = etrans_thy_fs[-1].path(thy_locs)
 #     print(etrans_thy_path)
-#     spc_path = print(etrans_spc_s.leaf.path(spc_locs))
-#     print(etrans_spc_s.leaf.path(spc_locs))
+#     spc_path = print(etrans_spc_s[-1].path(spc_locs))
+#     print(etrans_spc_s[-1].path(spc_locs))
 #     locs = ['InChI=1S/C2H2F2/c3-1-2-4/h1-2H/b2-1+', 0, 1]
-#     etrans_fs.leaf.create(locs)
-#     print(etrans_fs.leaf.path(locs))
+#     etrans_fs[-1].create(locs)
+#     print(etrans_fs[-1].path(locs))
 #
 #     ref_eps = 300.0
 #     ref_sig = 3.50
-#     print(etrans_fs.leaf.file.lennard_jones_epsilon.path(locs))
-#     print(etrans_fs.leaf.file.lennard_jones_sigma.path(locs))
-#     # etrans_fs.leaf.create(locs)
-#     etrans_fs.leaf.file.lennard_jones_epsilon.write(ref_eps, locs)
-#     etrans_fs.leaf.file.lennard_jones_sigma.write(ref_sig, locs)
-#     assert etrans_fs.leaf.file.lennard_jones_epsilon.read(locs) == ref_eps
-#     assert etrans_fs.leaf.file.lennard_jones_sigma.read(locs) == ref_sig
+#     print(etrans_fs[-1].file.lennard_jones_epsilon.path(locs))
+#     print(etrans_fs[-1].file.lennard_jones_sigma.path(locs))
+#     # etrans_fs[-1].create(locs)
+#     etrans_fs[-1].file.lennard_jones_epsilon.write(ref_eps, locs)
+#     etrans_fs[-1].file.lennard_jones_sigma.write(ref_sig, locs)
+#     assert etrans_fs[-1].file.lennard_jones_epsilon.read(locs) == ref_eps
+#     assert etrans_fs[-1].file.lennard_jones_sigma.read(locs) == ref_sig
 
 
 def test__scan():
@@ -185,13 +185,13 @@ def test__scan():
 
     scn_fs = autofile.fs.scan(prefix)
     locs = [['d3', 'd4'], [2, 3]]
-    print(scn_fs.leaf.path(locs))
+    print(scn_fs[-1].path(locs))
 
     ref_inp_str = '<input string>'
-    print(scn_fs.leaf.file.geometry_input.path(locs))
-    scn_fs.leaf.create(locs)
-    scn_fs.leaf.file.geometry_input.write(ref_inp_str, locs)
-    assert scn_fs.leaf.file.geometry_input.read(locs) == ref_inp_str
+    print(scn_fs[-1].file.geometry_input.path(locs))
+    scn_fs[-1].create(locs)
+    scn_fs[-1].file.geometry_input.write(ref_inp_str, locs)
+    assert scn_fs[-1].file.geometry_input.read(locs) == ref_inp_str
 
 
 def test__cscan():
@@ -203,13 +203,13 @@ def test__cscan():
     scn_fs = autofile.fs.cscan(prefix)
     # the dictionary at the end specifies the constraint values
     locs = [['d3', 'd4'], [1.2, 2.9], {'r1': 1., 'a2': 2.3}]
-    print(scn_fs.leaf.path(locs))
+    print(scn_fs[-1].path(locs))
 
     ref_inp_str = '<input string>'
-    print(scn_fs.leaf.file.geometry_input.path(locs))
-    scn_fs.leaf.create(locs)
-    scn_fs.leaf.file.geometry_input.write(ref_inp_str, locs)
-    assert scn_fs.leaf.file.geometry_input.read(locs) == ref_inp_str
+    print(scn_fs[-1].file.geometry_input.path(locs))
+    scn_fs[-1].create(locs)
+    scn_fs[-1].file.geometry_input.write(ref_inp_str, locs)
+    assert scn_fs[-1].file.geometry_input.read(locs) == ref_inp_str
 
 
 def test__run():
@@ -219,13 +219,13 @@ def test__run():
     os.mkdir(prefix)
 
     run_fs = autofile.fs.run(prefix)
-    print(run_fs.leaf.path(['gradient']))
+    print(run_fs[-1].path(['gradient']))
 
     ref_inp_str = '<input string>'
-    print(run_fs.leaf.file.input.path(['gradient']))
-    run_fs.leaf.create(['gradient'])
-    run_fs.leaf.file.input.write(ref_inp_str, ['gradient'])
-    assert run_fs.leaf.file.input.read(['gradient']) == ref_inp_str
+    print(run_fs[-1].file.input.path(['gradient']))
+    run_fs[-1].create(['gradient'])
+    run_fs[-1].file.input.write(ref_inp_str, ['gradient'])
+    assert run_fs[-1].file.input.read(['gradient']) == ref_inp_str
 
 
 def test__build():
@@ -235,19 +235,19 @@ def test__build():
     os.mkdir(prefix)
 
     build_fs = autofile.fs.build(prefix)
-    print(build_fs.leaf.path(['MESS', 0]))
+    print(build_fs[-1].path(['MESS', 0]))
 
     ref_inp_str = '<input string>'
-    print(build_fs.leaf.file.input.path(['MESS', 0]))
-    build_fs.leaf.create(['MESS', 0])
-    build_fs.leaf.file.input.write(ref_inp_str, ['MESS', 0])
-    assert build_fs.leaf.file.input.read(['MESS', 0]) == ref_inp_str
+    print(build_fs[-1].file.input.path(['MESS', 0]))
+    build_fs[-1].create(['MESS', 0])
+    build_fs[-1].file.input.write(ref_inp_str, ['MESS', 0])
+    assert build_fs[-1].file.input.read(['MESS', 0]) == ref_inp_str
 
 
 if __name__ == '__main__':
-    # test__direction()
-    # test__species()
-    # test__reaction()
+    test__direction()
+    test__species()
+    test__reaction()
     # test__ts()
     # test__theory()
     # test__conformer()
@@ -257,4 +257,4 @@ if __name__ == '__main__':
     # test__scan()
     # test__run()
     # test__build()
-    test__cscan()
+    # test__cscan()

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,8 @@
+autofile interface
+==================
+
+.. contents::
+    :local:
+
+.. automodule:: autofile.fs
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'autofile'
+copyright = '2020, Andreas V. Copan'
+author = 'Andreas V. Copan'
+
+# The full version, including alpha/beta/rc tags
+release = '0.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinx.ext.autodoc']
+master_doc = 'index'
+autodoc_mock_imports = ['numpy', 'automol', 'yaml', 'autoparse', 'elstruct']
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+.. autofile documentation master file, created by
+   sphinx-quickstart on Sat Jan  4 14:42:44 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to autofile's documentation!
+====================================
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Contents:
+
+    api

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
Instead of interacting with the layers in a filesystem as fs.trunk, fs.branch, fs.leaf, we will use indices (fs[0], fs[1], etc.) for each layer. The downside is that the code will look slightly less like English. But there are some upsides:

1. The leaf (i.e. the final layer) can always be accessed using fs[-1], no matter how many layers there are. I expect that, 95% of the time, we are interacting with the leaf of a filesystem. No matter how many layers they are, we can always use spc_fs[-1], cnf_fs[-1], thy_fs[-1], etc. to refer to the last layer, and we can always use spc_fs[0], cnf_fs[0], thy_fs[0], etc. to refer to the first layer.

1. For single-layer filesystems, we can use either fs[0] or fs[-1] to access the layer -- both work, and they refer to the same thing. I think that will be more intuitive than the current scheme, where it isn't necessarily obvious from a user perspective whether the layer will be called fs.trunk or fs.leaf.

1. Moving forward, I foresee a need for more than three layers. I already ran into this for the constrained-scan filesystem we talked about a few weeks ago. In that case I ended up using fs.trunk, fs.branch1, fs.branch2, and fs.leaf, which I suspect will get confusing. To me, referring to these as fs[0], fs[1], fs[2], and fs[-1] makes just as much sense and it allows us to maintain a consistent scheme for any number of layers.

My thinking is that trunk, branch, and leaf aren't that meaningful in the first place, so it's not a huge loss of readability.
